### PR TITLE
Enable lazy removal of keys

### DIFF
--- a/root-files/opt/flownative/lib/redis.sh
+++ b/root-files/opt/flownative/lib/redis.sh
@@ -113,6 +113,9 @@ redis_initialize() {
     redis_conf_set maxmemory "${REDIS_MAXMEMORY}"
     redis_conf_set maxmemory-policy "${REDIS_MAXMEMORY_POLICY}"
     redis_conf_set databases "${REDIS_DATABASES}"
+    redis_conf_set lazyfree-lazy-expire yes
+    redis_conf_set lazyfree-lazy-server-del yes
+    redis_conf_set lazyfree-lazy-user-del yes
     redis_conf_unset save
     if [[ -n "${REDIS_PASSWORD}" ]]; then
         redis_conf_set requirepass "${REDIS_PASSWORD}"


### PR DESCRIPTION
This should give a good performance boost for typical applications.

We allow redis to lazily reclaim keys that expired or were deleted by server operations (overwrites/replaces) as well as user deletes.

This will free the memory a bit later in async processes but finish the operation much faster keeping responsiveness high. Should be helpful in big publish / cache flush scenarios with Neos.