### PR TITLE
Allow overwriting the hz configuration setting with env

### DIFF
--- a/root-files/opt/flownative/lib/redis.sh
+++ b/root-files/opt/flownative/lib/redis.sh
@@ -29,6 +29,7 @@ export REDIS_DAEMON_GROUP="redis"
 export REDIS_DISABLE_COMMANDS="${REDIS_DISABLE_COMMANDS:-}"
 export REDIS_PASSWORD="${REDIS_PASSWORD:-}"
 export REDIS_ALLOW_EMPTY_PASSWORD="${REDIS_ALLOW_EMPTY_PASSWORD:-no}"
+export REDIS_HZ="${REDIS_HZ:-10}"
 EOF
     if [[ -f "${REDIS_PASSWORD_FILE:-}" ]]; then
         cat <<"EOF"
@@ -113,6 +114,7 @@ redis_initialize() {
     redis_conf_set maxmemory "${REDIS_MAXMEMORY}"
     redis_conf_set maxmemory-policy "${REDIS_MAXMEMORY_POLICY}"
     redis_conf_set databases "${REDIS_DATABASES}"
+    redis_conf_set hz "${REDIS_HZ}"
     redis_conf_unset save
     if [[ -n "${REDIS_PASSWORD}" ]]; then
         redis_conf_set requirepass "${REDIS_PASSWORD}"


### PR DESCRIPTION
The hz configuration determines how often redis operates background processes like key reclaims and active expire checks.

In busy instances with many changes we might want to set this higher than the default (10). This change will have no effect if the environment variable (`REDIS_HZ`) is not set as we keep the default as is.