### PR TITLE
Enable activedefrag in Redis

### DIFF
--- a/root-files/opt/flownative/lib/redis.sh
+++ b/root-files/opt/flownative/lib/redis.sh
@@ -113,6 +113,7 @@ redis_initialize() {
 
     redis_conf_set maxmemory "${REDIS_MAXMEMORY}"
     redis_conf_set maxmemory-policy "${REDIS_MAXMEMORY_POLICY}"
+    redis_conf_set activedefrag yes
     redis_conf_set databases "${REDIS_DATABASES}"
     redis_conf_set lazyfree-lazy-expire yes
     redis_conf_set lazyfree-lazy-server-del yes


### PR DESCRIPTION
Over time, Redis's memory allocation can become fragmented, especially in environments with a large number and variety of write, delete, and update operations. Redis 4.0 and newer versions include an active memory defragmentation feature, which helps in reclaiming unused memory and reducing fragmentation.