### PR TITLE
Disable RDB persistence properly and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,36 @@ A Docker image providing Redis for [Beach](https://www.flownative.com/beach),
 
 ### Environment variables
 
-| Variable Name              | Type    | Default                   | Description                                    |
-|:---------------------------|:--------|:--------------------------|:-----------------------------------------------|
-| REDIS_BASE_PATH            | string  | /opt/flownative/redis     | Base path for Redis (read-only)                |
-| REDIS_CONF_PATH            | string  | /opt/flownative/redis/etc | Configuration path for Redis (read-only)       |
-| REDIS_DATABASES            | integer | 50                        | Maximum number of databases                    |
-| REDIS_MAXMEMORY            | string  | 150mb                     | Maximum memory                                 |
-| REDIS_MAXMEMORY_POLICY     | string  | allkeys-lru               | Policy for dealing with exhausted memory limit |
-| REDIS_DAEMON_USER          | string  | redis                     | Username for Redis daemon (read-only)          |
-| REDIS_DAEMON_GROUP         | string  | redis                     | Group for Redis daemon (read-only)             |
-| REDIS_DISABLE_COMMANDS     | string  |                           | A list of commands to disable                  |
-| REDIS_PASSWORD             | string  |                           | A clear text password for Redis authentication |
-| REDIS_ALLOW_EMPTY_PASSWORD | boolean | false                     | If Redis may start without a password set      |
+| Variable Name                     | Type    | Default                   | Description                                                          |
+|:----------------------------------|:--------|:--------------------------|:---------------------------------------------------------------------|
+| REDIS_BASE_PATH                   | string  | /opt/flownative/redis     | Base path for Redis (read-only)                                      |
+| REDIS_CONF_PATH                   | string  | /opt/flownative/redis/etc | Configuration path for Redis (read-only)                             |
+| REDIS_DATABASES                   | integer | 50                        | Maximum number of databases                                          |
+| REDIS_MAXMEMORY                   | string  | 150mb                     | Maximum memory                                                       |
+| REDIS_MAXMEMORY_POLICY            | string  | allkeys-lru               | Policy for dealing with exhausted memory limit                       |
+| REDIS_DAEMON_USER                 | string  | redis                     | Username for Redis daemon (read-only)                                |
+| REDIS_DAEMON_GROUP                | string  | redis                     | Group for Redis daemon (read-only)                                   |
+| REDIS_DISABLE_COMMANDS            | string  |                           | A list of commands to disable                                        |
+| REDIS_PASSWORD                    | string  |                           | A clear text password for Redis authentication                       |
+| REDIS_ALLOW_EMPTY_PASSWORD        | boolean | false                     | If Redis may start without a password set                            |
+| REDIS_SAVE                        | string  |                           | RDB snapshot save points (e.g. `3600 1`); empty disables persistence |
+| REDIS_STOP_WRITES_ON_BGSAVE_ERROR | boolean | no                        | If Redis should reject writes when an RDB snapshot fails             |
+
+### Persistence
+
+By default this image runs Redis as a pure cache: RDB snapshotting is **disabled**
+(`save ""`) and `stop-writes-on-bgsave-error` is set to `no`. No data is written to
+disk and there is nothing to persist across restarts.
+
+To enable RDB snapshots, set `REDIS_SAVE` to one or more save points, e.g.
+`REDIS_SAVE="3600 1"` (snapshot if at least 1 key changed within 3600 seconds). Make
+sure the data directory `/var/lib/redis` is writable by the daemon (uid 1000) — when
+running in Kubernetes, mount a writable volume (e.g. a `PersistentVolumeClaim`) there.
+
+To disable persistence again, leave `REDIS_SAVE` empty. Note that simply removing all
+`save` directives is not enough: without any `save` directive Redis falls back to its
+compiled-in default save points and keeps snapshotting. An explicit empty `save` is
+required, which is exactly what this image configures when `REDIS_SAVE` is empty.
 
 ## Helm Chart
 

--- a/root-files/build.sh
+++ b/root-files/build.sh
@@ -20,7 +20,11 @@ mv /usr/bin/redis* "${REDIS_BASE_PATH}/bin/"
 chown -R root:root "${REDIS_BASE_PATH}"
 chmod -R g+rwX "${REDIS_BASE_PATH}"
 
-chown -R root:root /var/lib/redis
+# The data directory must be writable by the redis daemon (uid 1000), otherwise
+# RDB snapshotting fails with a MISCONF error as soon as persistence is enabled.
+# In Kubernetes this path is usually masked by a (world-writable) emptyDir volume,
+# but standalone (e.g. Local Beach) the image-internal directory is used.
+chown -R redis:redis /var/lib/redis
 chmod -R 755 /var/lib/redis
 
 chmod 664 "${REDIS_BASE_PATH}/etc/redis-default.conf"

--- a/root-files/opt/flownative/lib/redis.sh
+++ b/root-files/opt/flownative/lib/redis.sh
@@ -30,6 +30,8 @@ export REDIS_DISABLE_COMMANDS="${REDIS_DISABLE_COMMANDS:-}"
 export REDIS_PASSWORD="${REDIS_PASSWORD:-}"
 export REDIS_ALLOW_EMPTY_PASSWORD="${REDIS_ALLOW_EMPTY_PASSWORD:-no}"
 export REDIS_HZ="${REDIS_HZ:-10}"
+export REDIS_SAVE="${REDIS_SAVE:-}"
+export REDIS_STOP_WRITES_ON_BGSAVE_ERROR="${REDIS_STOP_WRITES_ON_BGSAVE_ERROR:-no}"
 EOF
     if [[ -f "${REDIS_PASSWORD_FILE:-}" ]]; then
         cat <<"EOF"
@@ -118,7 +120,15 @@ redis_initialize() {
     redis_conf_set lazyfree-lazy-server-del yes
     redis_conf_set lazyfree-lazy-user-del yes
     redis_conf_set hz "${REDIS_HZ}"
-    redis_conf_unset save
+
+    # Persistence: this image is used as a pure cache, so RDB snapshotting is
+    # disabled by default (save ""). Important: merely removing the save directives
+    # is NOT enough — without any save directive Redis falls back to its compiled-in
+    # default save points (3600 1 / 300 100 / 60 10000) and keeps snapshotting. An
+    # explicit empty save is required to actually turn it off.
+    # Set REDIS_SAVE (e.g. "3600 1") to enable snapshotting again.
+    redis_conf_set save "${REDIS_SAVE}"
+    redis_conf_set stop-writes-on-bgsave-error "${REDIS_STOP_WRITES_ON_BGSAVE_ERROR}"
     if [[ -n "${REDIS_PASSWORD}" ]]; then
         redis_conf_set requirepass "${REDIS_PASSWORD}"
     else


### PR DESCRIPTION
The library called `redis_conf_unset save` to turn off RDB snapshotting, but merely removing the `save` directives is not enough: without any `save` directive Redis falls back to its **compiled-in default save points** (`3600 1` / `300 100` / `60 10000`) and keeps snapshotting.

Because the data directory `/var/lib/redis` was owned by `root:root` while the daemon runs as uid 1000, every snapshot failed with:

```
MISCONF Redis is configured to save RDB snapshots, but it's currently unable
to persist to disk. Commands that may modify the data set are disabled ...
```

Together with `stop-writes-on-bgsave-error yes` this caused Redis to **reject all writes**. In Kubernetes the issue is masked by a world-writable `emptyDir` volume mounted at `/var/lib/redis` (so `bgsave` happens to succeed), but standalone — e.g. Local Beach without that volume — it surfaces as failing cache writes and a flood of `Neos.Cache` errors.

Since this image is used as a pure cache (and the production volume is an ephemeral `emptyDir` anyway), the snapshots persist nothing but cost fork/CoW memory and CPU.

## Changes

- Set an explicit empty `save` to **actually** disable snapshotting, configurable via the new `REDIS_SAVE` env var
- Make `stop-writes-on-bgsave-error` configurable via the new `REDIS_STOP_WRITES_ON_BGSAVE_ERROR` env var (default: `no`)
- Let the `redis` user (uid 1000) own `/var/lib/redis`, so persistence works standalone when enabled (defense in depth)
- Document the new variables and add a **Persistence** section to the README

## Rollout notes

Pure cache image, no persistent data is lost. After building & pushing the new image, roll the Redis pods / recreate the Local Beach Redis container.